### PR TITLE
Add ESP32Features to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome ESP8266/32 projects and code.
 - [Tasmotizer](https://github.com/tasmota/tasmotizer) - A graphical flashing tool for Tasmota firmware. Can manage Wi-Fi & MQTT settings, modules & templates.
 - [Arduino FS Plugin](https://github.com/esp8266/arduino-esp8266fs-plugin) - An Arduino plugin for filesystem uploads in the 8266.
 - [PlatformIO](https://github.com/platformio/platformio-core) - Cross Platform IDE and Debugger that supports both the ESP32 and ESP8266.
-- [ESP32Features](https://github.com/artkeller/ESP32Features) - Datasheet-derived comparison of all 14 current ESP32 SoC variants, covering deep sleep behavior, security/PQC readiness, and multi-chip combination guidance.
+- [ESP32Features](https://github.com/artkeller/ESP32Features) - Datasheet-derived comparison of all 14 current ESP32 SoC variants, covering deep sleep behavior, security/PQC readiness, and multi-chip combination guidance. 
 
 ## Projects
 ### Smart Home and IoT

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome ESP8266/32 projects and code.
 - [Tasmotizer](https://github.com/tasmota/tasmotizer) - A graphical flashing tool for Tasmota firmware. Can manage Wi-Fi & MQTT settings, modules & templates.
 - [Arduino FS Plugin](https://github.com/esp8266/arduino-esp8266fs-plugin) - An Arduino plugin for filesystem uploads in the 8266.
 - [PlatformIO](https://github.com/platformio/platformio-core) - Cross Platform IDE and Debugger that supports both the ESP32 and ESP8266.
+- [ESP32Features](https://github.com/artkeller/ESP32Features) - Datasheet-derived comparison of all 14 current ESP32 SoC variants, covering deep sleep behavior, security/PQC readiness, and multi-chip combination guidance.
 
 ## Projects
 ### Smart Home and IoT


### PR DESCRIPTION
Adds a datasheet-derived reference comparing all 14 current ESP32 SoC variants (ESP32 through S31), covering deep sleep behavior per model, cryptographic/post-quantum readiness, and reasoned multi-chip combinations. Community-maintained, not affiliated with Espressif, all figures tied to specific datasheet versions.